### PR TITLE
Fix macOS permissions issues when intalling Lima

### DIFF
--- a/get_rfswift.sh
+++ b/get_rfswift.sh
@@ -1166,8 +1166,12 @@ install_lima_fork() {
 
   color_echo "blue" "Installing Lima ${LIMA_VERSION} (PentHertz fork with USB support)..."
   curl -fsSL "$url" -o "$tmp"
-  sudo tar xz -C /usr/local -f "$tmp"
+  mkdir /tmp/lima
+  sudo tar xz -C /tmp/lima -f "$tmp"
+  rsync -a /tmp/lima/* /usr/local
+  #sudo tar xz -C /usr/local -f "$tmp"
   rm -f "$tmp"
+  rm -r /tmp/lima
 
   if ! command_exists limactl; then
     color_echo "red" "Lima installation failed — limactl not found in PATH."


### PR DESCRIPTION
This modification get around the permissions issues that macOS puts on /usr/local and instead extracts the tar in tmp and then moved the files to the correct sub folders.